### PR TITLE
Added support for verifying the allow limit without incrementing it.

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,7 +39,8 @@ func statusHandler(w http.ResponseWriter, req *http.Request, rateLimiter *rate.L
 	userID := "user-12345"
 	limit := int64(5)
 
-	rate, reset, allowed := rateLimiter.VerifyMinute(userID, limit)
+	//With increment 0, we just retrieve the current limit
+	rate, reset, allowed := rateLimiter.AllowN(userID, limit, time.Minute, 0)
 	fmt.Fprintf(w, "Current rate: %d", rate)
 	fmt.Fprintf(w, "Reset: %d", reset)
 	fmt.Fprintf(w, "Allowed: %v", allowed)

--- a/README.md
+++ b/README.md
@@ -35,6 +35,16 @@ func handler(w http.ResponseWriter, req *http.Request, rateLimiter *rate.Limiter
 	fmt.Fprint(w, "Rate limit remaining: ", strconv.FormatInt(limit-rate, 10))
 }
 
+func statusHandler(w http.ResponseWriter, req *http.Request, rateLimiter *rate.Limiter) {
+	userID := "user-12345"
+	limit := int64(5)
+
+	rate, reset, allowed := rateLimiter.VerifyMinute(userID, limit)
+	fmt.Fprintf(w, "Current rate: %d", rate)
+	fmt.Fprintf(w, "Reset: %d", reset)
+	fmt.Fprintf(w, "Allowed: %v", allowed)
+}
+
 func main() {
 	ring := redis.NewRing(&redis.RingOptions{
 		Addrs: map[string]string{
@@ -46,6 +56,10 @@ func main() {
 
 	http.HandleFunc("/", func(w http.ResponseWriter, req *http.Request) {
 		handler(w, req, limiter)
+	})
+
+	http.HandleFunc("/status", func(w http.ResponseWriter, req *http.Request) {
+		statusHandler(w, req, limiter)
 	})
 
 	http.HandleFunc("/favicon.ico", http.NotFound)

--- a/rate.go
+++ b/rate.go
@@ -102,7 +102,7 @@ func (l *Limiter) Verify(name string, maxn int64, dur time.Duration) (count, res
 	allow = l.fallbackLimiter.Allow()
 
 	name = fmt.Sprintf("%s:%s-%d", redisPrefix, name, slot)
-	count, err := l.get(name, dur)
+	count, err := l.get(name)
 	if err == nil {
 		allow = count <= maxn
 	}
@@ -132,7 +132,7 @@ func (l *Limiter) incr(name string, dur time.Duration) (int64, error) {
 	return rate, err
 }
 
-func (l *Limiter) get(name string, dur time.Duration) (int64, error) {
+func (l *Limiter) get(name string) (int64, error) {
 	var getCmd *redis.StringCmd
 	_, err := l.redis.Pipelined(func(pipe *redis.Pipeline) error {
 		getCmd = pipe.Get(name)

--- a/rate.go
+++ b/rate.go
@@ -1,12 +1,13 @@
-package rate // import "gopkg.in/go-redis/rate.v4"
+package rate
 
 import (
 	"fmt"
+	"strconv"
 	"time"
 
-	timerate "golang.org/x/time/rate"
+	redis "gopkg.in/redis.v4"
 
-	"gopkg.in/redis.v4"
+	timerate "golang.org/x/time/rate"
 )
 
 const redisPrefix = "rate"
@@ -91,6 +92,34 @@ func (l *Limiter) AllowRate(name string, rateLimit timerate.Limit) (delay time.D
 	return delay, allow
 }
 
+// Verify reports whether an event with given name may happen at time now.
+// It allows up to maxn events within duration dur.
+// The difference for the Allow method is that this method does not increment usage.
+func (l *Limiter) Verify(name string, maxn int64, dur time.Duration) (count, reset int64, allow bool) {
+	udur := int64(dur / time.Second)
+	slot := time.Now().Unix() / udur
+	reset = (slot + 1) * udur
+	allow = l.fallbackLimiter.Allow()
+
+	name = fmt.Sprintf("%s:%s-%d", redisPrefix, name, slot)
+	count, err := l.get(name, dur)
+	if err == nil {
+		allow = count <= maxn
+	}
+
+	return count, reset, allow
+}
+
+// VerifyMinute is shorthand for Verify(name, maxn, time.Minute).
+func (l *Limiter) VerifyMinute(name string, maxn int64) (int64, int64, bool) {
+	return l.Verify(name, maxn, time.Minute)
+}
+
+// VerifyHour is shorthand for Verify(name, maxn, time.Hour).
+func (l *Limiter) VerifyHour(name string, maxn int64) (int64, int64, bool) {
+	return l.Verify(name, maxn, time.Hour)
+}
+
 func (l *Limiter) incr(name string, dur time.Duration) (int64, error) {
 	var incr *redis.IntCmd
 	_, err := l.redis.Pipelined(func(pipe *redis.Pipeline) error {
@@ -100,5 +129,24 @@ func (l *Limiter) incr(name string, dur time.Duration) (int64, error) {
 	})
 
 	rate, _ := incr.Result()
+	return rate, err
+}
+
+func (l *Limiter) get(name string, dur time.Duration) (int64, error) {
+	var getCmd *redis.StringCmd
+	_, err := l.redis.Pipelined(func(pipe *redis.Pipeline) error {
+		getCmd = pipe.Get(name)
+		return nil
+	})
+
+	rate := int64(0)
+	rateStr, _ := getCmd.Result()
+	if rateStr != "" {
+		rateInt, err := strconv.ParseInt(rateStr, 10, 64)
+		if err != nil {
+			return 0, err
+		}
+		rate = int64(rateInt)
+	}
 	return rate, err
 }

--- a/rate_test.go
+++ b/rate_test.go
@@ -108,14 +108,14 @@ func TestRedisIsDown(t *testing.T) {
 	}
 }
 
-func TestVerify(t *testing.T) {
+func TestAllowN(t *testing.T) {
 	l := rateLimiter()
 
-	rate, reset, allow := l.Verify("test_verify_id", 1, time.Minute)
+	rate, reset, allow := l.AllowN("test_allow_n", 1, time.Minute, 1)
 	if !allow {
 		t.Fatalf("rate limited with rate %d", rate)
 	}
-	if rate != 0 {
+	if rate != 1 {
 		t.Fatalf("got %d, wanted 1", rate)
 	}
 	dur := time.Duration(reset-time.Now().Unix()) * time.Second
@@ -123,15 +123,14 @@ func TestVerify(t *testing.T) {
 		t.Fatalf("got %s, wanted <= %s", dur, time.Minute)
 	}
 
-	l.Allow("test_verify_id", 1, time.Minute)
-	l.Allow("test_verify_id", 1, time.Minute)
+	l.AllowN("test_allow_n", 1, time.Minute, 2)
 
-	rate, reset, allow = l.Verify("test_verify_id", 1, time.Minute)
+	rate, reset, allow = l.AllowN("test_allow_n", 1, time.Minute, 0)
 	if allow {
 		t.Fatalf("should rate limit with rate %d", rate)
 	}
-	if rate != 2 {
-		t.Fatalf("got %d, wanted 1", rate)
+	if rate != 3 {
+		t.Fatalf("got %d, wanted 3", rate)
 	}
 	dur = time.Duration(reset-time.Now().Unix()) * time.Second
 	if dur > time.Minute {
@@ -139,67 +138,6 @@ func TestVerify(t *testing.T) {
 	}
 }
 
-func TestVerifyMinute(t *testing.T) {
-	l := rateLimiter()
-
-	rate, reset, allow := l.VerifyMinute("test_verify_minute_id", 1)
-	if !allow {
-		t.Fatalf("rate limited with rate %d", rate)
-	}
-	if rate != 0 {
-		t.Fatalf("got %d, wanted 1", rate)
-	}
-	dur := time.Duration(reset-time.Now().Unix()) * time.Second
-	if dur > time.Minute {
-		t.Fatalf("got %s, wanted <= %s", dur, time.Minute)
-	}
-
-	l.AllowMinute("test_verify_minute_id", 1)
-	l.AllowMinute("test_verify_minute_id", 1)
-
-	rate, reset, allow = l.VerifyMinute("test_verify_minute_id", 1)
-	if allow {
-		t.Fatalf("should rate limit with rate %d", rate)
-	}
-	if rate != 2 {
-		t.Fatalf("got %d, wanted 1", rate)
-	}
-	dur = time.Duration(reset-time.Now().Unix()) * time.Second
-	if dur > time.Minute {
-		t.Fatalf("got %s, wanted <= %s", dur, time.Minute)
-	}
-}
-
-func TestVerifyHour(t *testing.T) {
-	l := rateLimiter()
-
-	rate, reset, allow := l.VerifyHour("test_verify_hour_id", 1)
-	if !allow {
-		t.Fatalf("rate limited with rate %d", rate)
-	}
-	if rate != 0 {
-		t.Fatalf("got %d, wanted 1", rate)
-	}
-	dur := time.Duration(reset-time.Now().Unix()) * time.Second
-	if dur > time.Hour {
-		t.Fatalf("got %s, wanted <= %s", dur, time.Hour)
-	}
-
-	l.AllowHour("test_verify_hour_id", 1)
-	l.AllowHour("test_verify_hour_id", 1)
-
-	rate, reset, allow = l.VerifyHour("test_verify_hour_id", 1)
-	if allow {
-		t.Fatalf("should rate limit with rate %d", rate)
-	}
-	if rate != 2 {
-		t.Fatalf("got %d, wanted 1", rate)
-	}
-	dur = time.Duration(reset-time.Now().Unix()) * time.Second
-	if dur > time.Hour {
-		t.Fatalf("got %s, wanted <= %s", dur, time.Hour)
-	}
-}
 func durEqual(got, wanted time.Duration) bool {
 	return got > 0 && got < wanted
 }

--- a/rate_test.go
+++ b/rate_test.go
@@ -111,7 +111,7 @@ func TestRedisIsDown(t *testing.T) {
 func TestVerify(t *testing.T) {
 	l := rateLimiter()
 
-	rate, reset, allow := l.Verify("test_id", 1, time.Minute)
+	rate, reset, allow := l.Verify("test_verify_id", 1, time.Minute)
 	if !allow {
 		t.Fatalf("rate limited with rate %d", rate)
 	}
@@ -123,10 +123,10 @@ func TestVerify(t *testing.T) {
 		t.Fatalf("got %s, wanted <= %s", dur, time.Minute)
 	}
 
-	l.Allow("test_id", 1, time.Minute)
-	l.Allow("test_id", 1, time.Minute)
+	l.Allow("test_verify_id", 1, time.Minute)
+	l.Allow("test_verify_id", 1, time.Minute)
 
-	rate, reset, allow = l.Verify("test_id", 1, time.Minute)
+	rate, reset, allow = l.Verify("test_verify_id", 1, time.Minute)
 	if allow {
 		t.Fatalf("should rate limit with rate %d", rate)
 	}
@@ -142,7 +142,7 @@ func TestVerify(t *testing.T) {
 func TestVerifyMinute(t *testing.T) {
 	l := rateLimiter()
 
-	rate, reset, allow := l.VerifyMinute("test_id", 1)
+	rate, reset, allow := l.VerifyMinute("test_verify_minute_id", 1)
 	if !allow {
 		t.Fatalf("rate limited with rate %d", rate)
 	}
@@ -154,10 +154,10 @@ func TestVerifyMinute(t *testing.T) {
 		t.Fatalf("got %s, wanted <= %s", dur, time.Minute)
 	}
 
-	l.AllowMinute("test_id", 1)
-	l.AllowMinute("test_id", 1)
+	l.AllowMinute("test_verify_minute_id", 1)
+	l.AllowMinute("test_verify_minute_id", 1)
 
-	rate, reset, allow = l.VerifyMinute("test_id", 1)
+	rate, reset, allow = l.VerifyMinute("test_verify_minute_id", 1)
 	if allow {
 		t.Fatalf("should rate limit with rate %d", rate)
 	}
@@ -173,7 +173,7 @@ func TestVerifyMinute(t *testing.T) {
 func TestVerifyHour(t *testing.T) {
 	l := rateLimiter()
 
-	rate, reset, allow := l.VerifyHour("test_id", 1)
+	rate, reset, allow := l.VerifyHour("test_verify_hour_id", 1)
 	if !allow {
 		t.Fatalf("rate limited with rate %d", rate)
 	}
@@ -185,10 +185,10 @@ func TestVerifyHour(t *testing.T) {
 		t.Fatalf("got %s, wanted <= %s", dur, time.Hour)
 	}
 
-	l.AllowHour("test_id", 1)
-	l.AllowHour("test_id", 1)
+	l.AllowHour("test_verify_hour_id", 1)
+	l.AllowHour("test_verify_hour_id", 1)
 
-	rate, reset, allow = l.VerifyHour("test_id", 1)
+	rate, reset, allow = l.VerifyHour("test_verify_hour_id", 1)
 	if allow {
 		t.Fatalf("should rate limit with rate %d", rate)
 	}


### PR DESCRIPTION
This PR adds the capability to verify the limits without incrementing them. This is very useful in my use case where I have one route that is rate limited and another one that uses the limit value for additional computation.

I also changed the places where the repository was mentioned in order for my pull request to be compatible with your codebase (otherwise there would be imports to github.com/heynemann/rate).

Feel free to ask me to modify my code in order to get this merged.

Thanks for the great work.