### PR TITLE
teardown ability

### DIFF
--- a/rate.go
+++ b/rate.go
@@ -3,9 +3,7 @@ package rate // import "gopkg.in/go-redis/rate.v4"
 import (
 	"fmt"
 	"time"
-
 	redis "gopkg.in/redis.v4"
-
 	timerate "golang.org/x/time/rate"
 )
 
@@ -30,6 +28,21 @@ func NewLimiter(redis rediser, fallbackLimiter *timerate.Limiter) *Limiter {
 	}
 }
 
+//Delete deletes everything attached to a key.
+//Will delete all rate limiting attached to any given key.
+func (l *Limiter) Teardown(name string) (err error) {
+	keys, err := l.keys(name)
+	if err != nil {
+		return
+	}
+	
+	for _, k := range keys {
+		err = l.delete(k)
+	}
+	
+	return
+}
+
 // AllowN reports whether an event with given name may happen at time now.
 // It allows up to maxn events within duration dur, with each interaction
 // incrementing the limit by n.
@@ -38,13 +51,13 @@ func (l *Limiter) AllowN(name string, maxn int64, dur time.Duration, n int64) (c
 	slot := time.Now().Unix() / udur
 	reset = (slot + 1) * udur
 	allow = l.fallbackLimiter.Allow()
-
+	
 	name = fmt.Sprintf("%s:%s-%d", redisPrefix, name, slot)
 	count, err := l.incr(name, dur, n)
 	if err == nil {
 		allow = count <= maxn
 	}
-
+	
 	return count, reset, allow
 }
 
@@ -72,29 +85,60 @@ func (l *Limiter) AllowRate(name string, rateLimit timerate.Limit) (delay time.D
 	if rateLimit == timerate.Inf {
 		return 0, true
 	}
-
+	
 	dur := time.Second
 	limit := int64(rateLimit)
 	if limit == 0 {
 		limit = 1
 		dur *= time.Duration(1 / rateLimit)
 	}
-
+	
 	now := time.Now()
 	slot := now.UnixNano() / dur.Nanoseconds()
 	allow = l.fallbackLimiter.Allow()
-
+	
 	name = fmt.Sprintf("%s:%s-%d-%d", redisPrefix, name, dur, slot)
 	count, err := l.incr(name, dur, 1)
 	if err == nil {
 		allow = count <= limit
 	}
-
+	
 	if !allow {
 		delay = time.Duration(slot+1)*dur - time.Duration(now.UnixNano())
 	}
-
+	
 	return delay, allow
+}
+
+func (l *Limiter) delete(names ...string) (err error) {
+	var del *redis.IntCmd
+	_, err = l.redis.Pipelined(func(pipe *redis.Pipeline) error {
+		del = pipe.Del(names...)
+		return nil
+	})
+	
+	if err != nil {
+		return
+	}
+	
+	err = del.Err()
+	
+	return
+}
+
+func (l *Limiter) keys(name string) ([]string, error) {
+	var keys *redis.StringSliceCmd
+	_, err := l.redis.Pipelined(func(pipe *redis.Pipeline) error {
+		//hard coded since we know the format
+		keys = pipe.Keys("rate:" + name + "*")
+		return nil
+	})
+	
+	if err != nil {
+		return []string{}, err
+	}
+	
+	return keys.Result()
 }
 
 func (l *Limiter) incr(name string, dur time.Duration, n int64) (int64, error) {
@@ -104,7 +148,7 @@ func (l *Limiter) incr(name string, dur time.Duration, n int64) (int64, error) {
 		pipe.Expire(name, dur)
 		return nil
 	})
-
+	
 	rate, _ := incr.Result()
 	return rate, err
 }


### PR DESCRIPTION
Added the ability to "teardown" a single rate limited key. I realized if you write tests around this on a production api... the rate limiter can screw up the tests. 

This was a small idea, so I figured I would send a small pull request to see what/how you think this should potentially work if it is to be added. 